### PR TITLE
feat: add isEditable to the condition on bubble menu

### DIFF
--- a/packages/core/src/ui/editor/bubble-menu/index.tsx
+++ b/packages/core/src/ui/editor/bubble-menu/index.tsx
@@ -62,10 +62,11 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props) => {
       const { empty } = selection;
 
       // don't show bubble menu if:
+      // - the editor is not editable
       // - the selected node is an image
       // - the selection is empty
       // - the selection is a node selection (for drag handles)
-      if (editor.isActive("image") || empty || isNodeSelection(selection)) {
+      if (!editor.isEditable || editor.isActive("image") || empty || isNodeSelection(selection)) {
         return false;
       }
       return true;


### PR DESCRIPTION
This PR is originally from https://github.com/steven-tey/novel/pull/249

https://tiptap.dev/api/extensions/bubble-menu
The default behavior of the bubble menu seems to hide it when 'editable' is falsy.
However, in the current implementation, it appears to be overridden by `shouldShow`.

I have modified it within the PR to also consider `editor.isEditable`.

https://github.com/steven-tey/novel/issues/153


https://github.com/steven-tey/novel/assets/38897355/ddddd26b-bc12-4ac9-9c82-29877cdfbf8a

