### PR TITLE
fix: remove duplicate image extension usage and merge

### DIFF
--- a/packages/core/.prettierrc.json
+++ b/packages/core/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "singleQuote": false,
+  "bracketSpacing": true,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2
+}

--- a/packages/core/src/ui/editor/extensions/index.tsx
+++ b/packages/core/src/ui/editor/extensions/index.tsx
@@ -13,7 +13,6 @@ import Highlight from "@tiptap/extension-highlight";
 import SlashCommand from "./slash-command";
 import { InputRule } from "@tiptap/core";
 import UploadImagesPlugin from "@/ui/editor/plugins/upload-images";
-import UpdatedImage from "./updated-image";
 import CustomKeymap from "./custom-keymap";
 import DragAndDrop from "./drag-and-drop";
 
@@ -75,7 +74,7 @@ export const defaultExtensions = [
 
             tr.insert(start - 1, this.type.create(attributes)).delete(
               tr.mapping.map(start),
-              tr.mapping.map(end)
+              tr.mapping.map(end),
             );
           },
         }),
@@ -93,16 +92,25 @@ export const defaultExtensions = [
     },
   }),
   TiptapImage.extend({
+    HTMLAttributes: {
+      class: "novel-rounded-lg novel-border novel-border-stone-200",
+    },
+    addAttributes() {
+      return {
+        ...this.parent?.(),
+        width: {
+          default: null,
+        },
+        height: {
+          default: null,
+        },
+      };
+    },
     addProseMirrorPlugins() {
       return [UploadImagesPlugin()];
     },
   }).configure({
     allowBase64: true,
-    HTMLAttributes: {
-      class: "novel-rounded-lg novel-border novel-border-stone-200",
-    },
-  }),
-  UpdatedImage.configure({
     HTMLAttributes: {
       class: "novel-rounded-lg novel-border novel-border-stone-200",
     },

--- a/packages/core/src/ui/editor/index.tsx
+++ b/packages/core/src/ui/editor/index.tsx
@@ -114,7 +114,7 @@ export default function Editor({
         complete(
           getPrevText(e.editor, {
             chars: 5000,
-          })
+          }),
         );
         // complete(e.editor.storage.markdown.getMarkdown());
         va.track("Autocomplete Shortcut Used");


### PR DESCRIPTION
https://github.com/steven-tey/novel/issues/221

Editor起動時に妙な警告が出ているので、定義をマージします。

修正するたびにprettierでえらい差分が出ちゃうので.prettierrc.jsonも追加。