### PR TITLE
fix: wtp-3911 テーブルカラム追加・削除時にform内のsubmitが走る問題を修正

### DIFF
--- a/packages/core/src/ui/editor/table/index.tsx
+++ b/packages/core/src/ui/editor/table/index.tsx
@@ -9,8 +9,6 @@ interface TableMenuItem {
 }
 
 export const TableMenu = ({ editor }: { editor: any }) => {
-  if (!editor.isEditable) return null;
-
   const [tableLocation, setTableLocation] = useState(0);
   const items: TableMenuItem[] = [
     {
@@ -68,6 +66,8 @@ export const TableMenu = ({ editor }: { editor: any }) => {
     };
   }, [tableLocation]);
 
+  if (!editor.isEditable) return null;
+
   return (
     <section
       className="novel-absolute novel-left-2/4 novel-flex novel-translate-x-[-50%] novel-overflow-hidden novel-rounded novel-border novel-border-stone-200 novel-bg-white novel-shadow-xl novel-z-40"
@@ -78,6 +78,7 @@ export const TableMenu = ({ editor }: { editor: any }) => {
       {items.map((item) => (
         <button
           key={item.id}
+          type="button"
           onClick={item.command}
           className="novel-p-2 novel-text-stone-600 novel-hover:bg-stone-100 novel-active:bg-stone-200"
           title={item.name}


### PR DESCRIPTION
`button` の type が指定されていなかったので、Novelがform内にあるときにTableのカラムを追加や削除すると `button` の `submit` が発火してFormがSubmitしてしまっていた。

明示的に `type` を `button` にすることでこの問題を回避する。