### PR TITLE
feat: fix image resizer

### DIFF
--- a/packages/core/src/ui/editor/index.tsx
+++ b/packages/core/src/ui/editor/index.tsx
@@ -131,7 +131,7 @@ export default function Editor({
         className={className}
       >
         {editor && <EditorBubbleMenu editor={editor} />}
-        {editor?.isActive("image") && <ImageResizer editor={editor} />}
+        {editor?.isActive("image") && editor?.isEditable && <ImageResizer editor={editor} />}
         {editor?.isActive("table") && <TableMenu editor={editor} />}
         <EditorContent editor={editor} />
       </div>


### PR DESCRIPTION
- image resizer を readOnly モードの際は表示しないようにしました。
- これにより画像を readOnly モードでも消せてしまうバグを解消できます。


https://github.com/sheinc/novel/assets/38897355/55cc0ad0-4738-4036-b6cf-36203b355b47

