### PR TITLE
feat: change line height

### DIFF
--- a/packages/core/src/styles/prosemirror.css
+++ b/packages/core/src/styles/prosemirror.css
@@ -135,16 +135,19 @@ div[contenteditable="false"]
 .ProseMirror h1 {
   font-size: 1.5rem;
   font-weight: 600;
+  line-height: 1.5;
 }
 
 .ProseMirror h2 {
   font-size: 1.25rem;
   font-weight: 600;
+  line-height: 1.5;
 }
 
 .ProseMirror h3 {
   font-size: 1.125rem;
   font-weight: 600;
+  line-height: 1.5;
 }
 
 /* Overwrite table styles */


### PR DESCRIPTION
slack:
https://sheinc.slack.com/archives/C02N557HFNF/p1705891137807269?thread_ts=1705034179.431749&cid=C02N557HFNF

> 見出し（h1/h2/h3）のline-height: 1.5 にお願いできますでしょうか
> 背景色つけたときに上下の余裕がなく違和感があるため


https://github.com/sheinc/novel/assets/38897355/a3243fd5-76dd-4a09-a624-7616c7a4c5d8

