### PR TITLE
feat: vimeoをnovelに埋め込みたい

### DIFF
--- a/packages/core/src/ui/editor/extensions/index.tsx
+++ b/packages/core/src/ui/editor/extensions/index.tsx
@@ -100,13 +100,14 @@ export const defaultExtensions = [
       class: "novel-mt-4 novel-mb-6 novel-border-t novel-border-stone-300",
     },
   }),
+  // CAUTION: Youtube link をペーストしたときには、EmbedVideo が使われる。しかし、すでに作成された youtube node を描画するためにこの Extension は残しておく。
   Youtube.configure({
     inline: false,
     controls: true,
     nocookie: false,
     allowFullscreen: true,
     autoplay: false,
-    addPasteHandler: false, // use EmbedVideo instead
+    addPasteHandler: false, // to use EmbedVideo instead
   }),
   EmbedVideo.configure({
     inline: false,

--- a/packages/core/src/ui/editor/extensions/index.tsx
+++ b/packages/core/src/ui/editor/extensions/index.tsx
@@ -22,6 +22,7 @@ import CustomKeymap from "./custom-keymap";
 import DragAndDrop from "./drag-and-drop";
 import { Heading } from "./custom-heading";
 import { Callout } from "./callout";
+import { EmbedVideo } from "./video-embed";
 
 export const defaultExtensions = [
   StarterKit.configure({
@@ -105,6 +106,11 @@ export const defaultExtensions = [
     nocookie: false,
     allowFullscreen: true,
     autoplay: false,
+    addPasteHandler: false, // use EmbedVideo instead
+  }),
+  EmbedVideo.configure({
+    inline: false,
+    controls: true,
   }),
   TiptapLink.configure({
     HTMLAttributes: {

--- a/packages/core/src/ui/editor/extensions/video-embed/index.ts
+++ b/packages/core/src/ui/editor/extensions/video-embed/index.ts
@@ -1,3 +1,5 @@
+// refs: https://github.com/ueberdosis/tiptap/blob/a863e1c49a0531ddfe06c4e73a427c109a4757db/packages/extension-youtube/src/youtube.ts
+
 import { isValidUrl } from "@/lib/utils";
 import { Node, mergeAttributes, nodePasteRule } from "@tiptap/core";
 import { GLOBAL_REGEX, VideoEmbedType, getEmbedUrl } from "./utils";

--- a/packages/core/src/ui/editor/extensions/video-embed/index.ts
+++ b/packages/core/src/ui/editor/extensions/video-embed/index.ts
@@ -1,0 +1,214 @@
+import { isValidUrl } from "@/lib/utils";
+import { Node, mergeAttributes, nodePasteRule } from "@tiptap/core";
+import { GLOBAL_REGEX, VideoEmbedType, getEmbedUrl } from "./utils";
+
+export interface EmbedOptions {
+  addPasteHandler: boolean;
+  allowFullscreen: boolean;
+  autoplay: boolean;
+  ccLanguage?: string;
+  ccLoadPolicy?: boolean;
+  controls: boolean;
+  disableKBcontrols: boolean;
+  enableIFrameApi: boolean;
+  endTime: number;
+  height: number;
+  interfaceLanguage?: string;
+  ivLoadPolicy: number;
+  loop: boolean;
+  modestBranding: boolean;
+  HTMLAttributes: Record<string, any>;
+  inline: boolean;
+  nocookie: boolean;
+  origin: string;
+  playlist: string;
+  progressBarColor?: string;
+  width: number;
+}
+
+type SetEmbedVideoOptions = {
+  src: string;
+  width?: number;
+  height?: number;
+  start?: number;
+};
+
+declare module "@tiptap/core" {
+  // eslint-disable-next-line no-unused-vars -- declared in the module
+  interface Commands<ReturnType> {
+    embed: {
+      /**
+       * Insert a youtube video
+       */
+      // eslint-disable-next-line no-unused-vars -- declared in the module
+      setEmbedVideo: (options: SetEmbedVideoOptions) => ReturnType;
+    };
+  }
+}
+
+export const EmbedVideo = Node.create({
+  name: "embed-video", // unique name for the Node
+  selectable: true, // so we can select the video
+  atom: true, // is a single unit
+
+  inline() {
+    return this.options.inline;
+  },
+
+  group() {
+    return this.options.inline ? "inline" : "block";
+  },
+
+  draggable: true,
+
+  addOptions() {
+    return {
+      addPasteHandler: true,
+      allowFullscreen: true,
+      autoplay: false,
+      ccLanguage: undefined,
+      ccLoadPolicy: undefined,
+      controls: true,
+      disableKBcontrols: false,
+      enableIFrameApi: false,
+      endTime: 0,
+      height: undefined,
+      interfaceLanguage: undefined,
+      ivLoadPolicy: 0,
+      loop: false,
+      modestBranding: false,
+      HTMLAttributes: {},
+      inline: false,
+      nocookie: false,
+      origin: "",
+      playlist: "",
+      progressBarColor: undefined,
+      width: undefined,
+    };
+  },
+
+  addAttributes() {
+    return {
+      src: {
+        default: null,
+      },
+      start: {
+        default: 0,
+      },
+      width: {
+        default: this.options.width,
+      },
+      height: {
+        default: this.options.height,
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "div[data-embed-video] iframe",
+      },
+    ];
+  },
+
+  addCommands() {
+    return {
+      setYoutubeVideo:
+        (options: SetEmbedVideoOptions) =>
+        ({ commands }) => {
+          if (!isValidUrl(options.src)) {
+            return false;
+          }
+
+          return commands.insertContent({
+            type: this.name,
+            attrs: options,
+          });
+        },
+    };
+  },
+
+  addPasteRules() {
+    if (!this.options.addPasteHandler) {
+      return [];
+    }
+
+    return [
+      nodePasteRule({
+        find: GLOBAL_REGEX,
+        type: this.type,
+        getAttributes: (match) => {
+          return {
+            src: match.input,
+          };
+        },
+      }),
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const [videoEmbedType, embedUrl] = getEmbedUrl({
+      url: HTMLAttributes.src,
+      allowFullscreen: this.options.allowFullscreen,
+      autoplay: this.options.autoplay,
+      ccLanguage: this.options.ccLanguage,
+      ccLoadPolicy: this.options.ccLoadPolicy,
+      controls: this.options.controls,
+      disableKBcontrols: this.options.disableKBcontrols,
+      enableIFrameApi: this.options.enableIFrameApi,
+      endTime: this.options.endTime,
+      interfaceLanguage: this.options.interfaceLanguage,
+      ivLoadPolicy: this.options.ivLoadPolicy,
+      loop: this.options.loop,
+      modestBranding: this.options.modestBranding,
+      nocookie: this.options.nocookie,
+      origin: this.options.origin,
+      playlist: this.options.playlist,
+      progressBarColor: this.options.progressBarColor,
+      startAt: HTMLAttributes.start || 0,
+    });
+
+    const DEFAULT_SIZE: Record<
+      VideoEmbedType,
+      { width: number; height: number }
+    > = {
+      youtube: { width: 640, height: 480 },
+      vimeo: { width: 640, height: 360 },
+    };
+
+    HTMLAttributes.src = embedUrl;
+    HTMLAttributes.width =
+      this.options.width ?? DEFAULT_SIZE[videoEmbedType].width;
+    HTMLAttributes.height =
+      this.options.height ?? DEFAULT_SIZE[videoEmbedType].height;
+
+    return [
+      "div",
+      { "data-embed-video": "" },
+      [
+        "iframe",
+        mergeAttributes(
+          this.options.HTMLAttributes,
+          {
+            allowfullscreen: this.options.allowFullscreen,
+            autoplay: this.options.autoplay,
+            ccLanguage: this.options.ccLanguage,
+            ccLoadPolicy: this.options.ccLoadPolicy,
+            disableKBcontrols: this.options.disableKBcontrols,
+            enableIFrameApi: this.options.enableIFrameApi,
+            endTime: this.options.endTime,
+            interfaceLanguage: this.options.interfaceLanguage,
+            ivLoadPolicy: this.options.ivLoadPolicy,
+            loop: this.options.loop,
+            modestBranding: this.options.modestBranding,
+            origin: this.options.origin,
+            playlist: this.options.playlist,
+            progressBarColor: this.options.progressBarColor,
+          },
+          HTMLAttributes,
+        ),
+      ],
+    ];
+  },
+});

--- a/packages/core/src/ui/editor/extensions/video-embed/index.ts
+++ b/packages/core/src/ui/editor/extensions/video-embed/index.ts
@@ -114,7 +114,7 @@ export const EmbedVideo = Node.create({
 
   addCommands() {
     return {
-      setYoutubeVideo:
+      setEmbedVideo:
         (options: SetEmbedVideoOptions) =>
         ({ commands }) => {
           if (!isValidUrl(options.src)) {

--- a/packages/core/src/ui/editor/extensions/video-embed/utils/index.ts
+++ b/packages/core/src/ui/editor/extensions/video-embed/utils/index.ts
@@ -1,0 +1,52 @@
+import {
+  YOUTUBE_REGEX_GLOBAL,
+  getEmbedUrlFromYoutubeUrl,
+  isValidYoutubeUrl,
+} from "./youtube";
+import {
+  VIMEO_REGEX_GLOBAL,
+  getEmbedUrlFromVimeoUrl,
+  isValidVimeoUrl,
+} from "./vimeo";
+
+export type VideoEmbedType = "youtube" | "vimeo";
+export interface GetEmbedUrlOptions {
+  url: string;
+  allowFullscreen?: boolean;
+  autoplay?: boolean;
+  ccLanguage?: string;
+  ccLoadPolicy?: boolean;
+  controls?: boolean;
+  disableKBcontrols?: boolean;
+  enableIFrameApi?: boolean;
+  endTime?: number;
+  interfaceLanguage?: string;
+  ivLoadPolicy?: number;
+  loop?: boolean;
+  modestBranding?: boolean;
+  nocookie?: boolean;
+  origin?: string;
+  playlist?: string;
+  progressBarColor?: string;
+  startAt?: number;
+}
+
+export const GLOBAL_REGEX = new RegExp(
+  `(${YOUTUBE_REGEX_GLOBAL.source})|(${VIMEO_REGEX_GLOBAL.source})`,
+  "g",
+);
+
+export const isValidUrl = (url: string) => {
+  return isValidYoutubeUrl(url) || isValidVimeoUrl(url);
+};
+
+export const getEmbedUrl = (
+  options: GetEmbedUrlOptions,
+): [VideoEmbedType, string | null] => {
+  if (isValidYoutubeUrl(options.url)) {
+    return ["youtube", getEmbedUrlFromYoutubeUrl(options)];
+  } else if (isValidVimeoUrl(options.url)) {
+    return ["vimeo", getEmbedUrlFromVimeoUrl(options)];
+  }
+  throw new Error("Invalid video URL");
+};

--- a/packages/core/src/ui/editor/extensions/video-embed/utils/vimeo.ts
+++ b/packages/core/src/ui/editor/extensions/video-embed/utils/vimeo.ts
@@ -10,6 +10,7 @@ export const isValidVimeoUrl = (url: string) => {
 };
 
 export const getEmbedUrlFromVimeoUrl = (options: GetEmbedUrlOptions) => {
+  // TODO: implement further options if needed
   const { url } = options;
 
   if (!isValidVimeoUrl(url)) {

--- a/packages/core/src/ui/editor/extensions/video-embed/utils/vimeo.ts
+++ b/packages/core/src/ui/editor/extensions/video-embed/utils/vimeo.ts
@@ -1,0 +1,26 @@
+import { GetEmbedUrlOptions } from ".";
+
+export const VIMEO_REGEX =
+  /^(https:\/\/player\.vimeo\.com\/video\/|https:\/\/vimeo\.com\/)\d+$/;
+export const VIMEO_REGEX_GLOBAL =
+  /^(https:\/\/player\.vimeo\.com\/video\/|https:\/\/vimeo\.com\/)\d+$/;
+
+export const isValidVimeoUrl = (url: string) => {
+  return url.match(VIMEO_REGEX);
+};
+
+export const getEmbedUrlFromVimeoUrl = (options: GetEmbedUrlOptions) => {
+  const { url } = options;
+
+  if (!isValidVimeoUrl(url)) {
+    return null;
+  }
+
+  if (!url.includes("player")) {
+    // NOTE: if the url is not an embed url, we need to convert it to an embed url
+    const videoId = url.match(/\d+/);
+    return `https://player.vimeo.com/video/${videoId}`;
+  }
+
+  return url;
+};

--- a/packages/core/src/ui/editor/extensions/video-embed/utils/youtube.ts
+++ b/packages/core/src/ui/editor/extensions/video-embed/utils/youtube.ts
@@ -1,0 +1,141 @@
+// refs: https://github.com/ueberdosis/tiptap/blob/a863e1c49a0531ddfe06c4e73a427c109a4757db/packages/extension-youtube/src/utils.ts
+
+import { GetEmbedUrlOptions } from ".";
+
+const YOUTUBE_REGEX =
+  /^(https?:\/\/)?(www\.|music\.)?(youtube\.com|youtu\.be|youtube-nocookie\.com)\/(?!channel\/)(?!@)(.+)?$/;
+export const YOUTUBE_REGEX_GLOBAL =
+  /^(https?:\/\/)?(www\.|music\.)?(youtube\.com|youtu\.be)\/(?!channel\/)(?!@)(.+)?$/g;
+
+export const isValidYoutubeUrl = (url: string) => {
+  return url.match(YOUTUBE_REGEX);
+};
+
+export const getYoutubeEmbedUrl = (nocookie?: boolean) => {
+  return nocookie
+    ? "https://www.youtube-nocookie.com/embed/"
+    : "https://www.youtube.com/embed/";
+};
+
+export const getEmbedUrlFromYoutubeUrl = (options: GetEmbedUrlOptions) => {
+  const {
+    url,
+    allowFullscreen,
+    autoplay,
+    ccLanguage,
+    ccLoadPolicy,
+    controls,
+    disableKBcontrols,
+    enableIFrameApi,
+    endTime,
+    interfaceLanguage,
+    ivLoadPolicy,
+    loop,
+    modestBranding,
+    nocookie,
+    origin,
+    playlist,
+    progressBarColor,
+    startAt,
+  } = options;
+
+  if (!isValidYoutubeUrl(url)) {
+    return null;
+  }
+
+  // if is already an embed url, return it
+  if (url.includes("/embed/")) {
+    return url;
+  }
+
+  // if is a youtu.be url, get the id after the /
+  if (url.includes("youtu.be")) {
+    const id = url.split("/").pop();
+
+    if (!id) {
+      return null;
+    }
+    return `${getYoutubeEmbedUrl(nocookie)}${id}`;
+  }
+
+  const videoIdRegex = /(?:v=|shorts\/)([-\w]+)/gm;
+  const matches = videoIdRegex.exec(url);
+
+  if (!matches || !matches[1]) {
+    return null;
+  }
+
+  let outputUrl = `${getYoutubeEmbedUrl(nocookie)}${matches[1]}`;
+
+  const params = [];
+
+  if (allowFullscreen === false) {
+    params.push("fs=0");
+  }
+
+  if (autoplay) {
+    params.push("autoplay=1");
+  }
+
+  if (ccLanguage) {
+    params.push(`cc_lang_pref=${ccLanguage}`);
+  }
+
+  if (ccLoadPolicy) {
+    params.push("cc_load_policy=1");
+  }
+
+  if (!controls) {
+    params.push("controls=0");
+  }
+
+  if (disableKBcontrols) {
+    params.push("disablekb=1");
+  }
+
+  if (enableIFrameApi) {
+    params.push("enablejsapi=1");
+  }
+
+  if (endTime) {
+    params.push(`end=${endTime}`);
+  }
+
+  if (interfaceLanguage) {
+    params.push(`hl=${interfaceLanguage}`);
+  }
+
+  if (ivLoadPolicy) {
+    params.push(`iv_load_policy=${ivLoadPolicy}`);
+  }
+
+  if (loop) {
+    params.push("loop=1");
+  }
+
+  if (modestBranding) {
+    params.push("modestbranding=1");
+  }
+
+  if (origin) {
+    params.push(`origin=${origin}`);
+  }
+
+  if (playlist) {
+    params.push(`playlist=${playlist}`);
+  }
+
+  if (startAt) {
+    params.push(`start=${startAt}`);
+  }
+
+  if (progressBarColor) {
+    params.push(`color=${progressBarColor}`);
+  }
+
+  if (params.length) {
+    outputUrl += `?${params.join("&")}`;
+  }
+
+  return outputUrl;
+};


### PR DESCRIPTION
## 概要

vimeoをnovelに埋め込めるようにしました。

## 実装の背景

現状 https://tiptap.dev/docs/editor/api/nodes/youtube を利用しています。
これにより YouTube のリンクを貼り付けたときに、自動で iframe が生成され埋め込まれるようになっています。

Vimeo に対しても同様の機能が欲しいという要望がありました。

## 方針

別途 Extension を実装する (3rd party の活用) もしくは、YouTube Extension を拡張するという 2 つの方針を考えました。
今回後者を採用したのは、vimeo のリンクが貼り付けたときに iframe を生成するという機能がほぼ YouTube Extension で実装されているものを使いまわせるためです。

具体的には

- https://github.com/ueberdosis/tiptap/blob/a863e1c49a0531ddfe06c4e73a427c109a4757db/packages/extension-youtube/src/youtube.ts#L121-L135 で実装されている正規表現を Vimeo にも対応させる
- Vimeo 用に iframe の表示を調整する

といった作業のみで実現が可能になります。

## Tips

### すでに運用されている YouTube Extension への扱い

YouTube Extension はすでに運用されているため、描画はできる必要があります。
そこで `addPasteHandler` https://github.com/ueberdosis/tiptap/blob/a863e1c49a0531ddfe06c4e73a427c109a4757db/packages/extension-youtube/src/youtube.ts#L122-L123 を falsy にすることで、リンクをペーストしても YouTube Extension が呼ばれないようにしています。

### Vimeo への対応

- 画面サイズが YouTube とは違うので、Regex へのヒット具合から YouTube か Vimeo かを識別して画面サイズを設定するようにしました。 https://github.com/sheinc/novel/pull/90#discussion_r1498480217
- 普通の共有用 URL と iframe に渡すべき URL が多少違うので、そちらを生成できるようにしました。 https://github.com/sheinc/novel/pull/90#discussion_r1498480821

## 動作

https://github.com/sheinc/novel/assets/38897355/5b3e1c28-3a38-4bb6-874d-1131f9e20a40

## Refs

TipTap custom extension
https://tiptap.dev/docs/editor/guide/custom-extensions

