### PR TITLE
feat: disable draggable icon when users are scrolling

### DIFF
--- a/packages/core/src/ui/editor/extensions/drag-and-drop.tsx
+++ b/packages/core/src/ui/editor/extensions/drag-and-drop.tsx
@@ -116,6 +116,7 @@ function DragHandle(options: DragHandleOptions) {
 
   return new Plugin({
     view: (view) => {
+      document.addEventListener("scroll", hideDragHandle);
       dragHandleElement = document.createElement("div");
       dragHandleElement.draggable = true;
       dragHandleElement.dataset.dragHandle = "";
@@ -133,6 +134,7 @@ function DragHandle(options: DragHandleOptions) {
 
       return {
         destroy: () => {
+          document.removeEventListener("scroll", hideDragHandle);
           dragHandleElement?.remove?.();
           dragHandleElement = null;
         },


### PR DESCRIPTION
Draggable icon をスクロール時には非表示にするようにしました。
scroll イベントは document 全体にかかるので、document に event handler 追加しています。


https://github.com/sheinc/novel/assets/38897355/fea8f670-e02c-48c7-b122-ba4a0a5cf917

