### PR TITLE
fix: NovelでコピーするとMarkdownが不自然に含まれる

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,26 +1,29 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
-	"name": "Node.js & TypeScript",
+	"name": "sheinc-novel",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-18-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {},
-		"ghcr.io/devcontainers/features/node:1": {}
-	}
-
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "20.17.0",
+			"pnpmVersion": "8"
+		}
+	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
-
 	// Configure tool-specific properties.
 	// "customizations": {},
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	// "remoteUser": "root",
+	// Mount local .pnpm-store into the container
+	"mounts": [
+		"source=${localEnv:HOME}/.pnpm-store,target=/home/node/.pnpm-store,type=bind,consistency=cached"
+	],
+	"postCreateCommand": "pnpm config set store-dir /home/node/.pnpm-store"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ packages/*/dist
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+# claude
+.claude/*.local.json

--- a/packages/core/src/ui/editor/extensions/index.tsx
+++ b/packages/core/src/ui/editor/extensions/index.tsx
@@ -203,7 +203,7 @@ export const defaultExtensions = [
   }),
   Markdown.configure({
     html: false,
-    transformCopiedText: true,
+    transformCopiedText: false,
     transformPastedText: true,
   }),
   CustomKeymap,


### PR DESCRIPTION

https://github.com/user-attachments/assets/91af9a98-45e9-4207-a8b6-c79976033dbb

`transformCopiedText` が悪さをしていたみたいです。Novel以外の場所へのコピペでMarkdownが入っていることでうれしいことって少ないはずなので、いったんこの機能を無効化しようかと思っています。（混乱の方が大きそうなので）

Novel内でのMarkdownは保持されてそうです！